### PR TITLE
media-fonts/nerd-fonts: replace ls with find

### DIFF
--- a/media-fonts/nerd-fonts/nerd-fonts-3.0.1-r1.ebuild
+++ b/media-fonts/nerd-fonts/nerd-fonts-3.0.1-r1.ebuild
@@ -168,8 +168,8 @@ src_install() {
 	declare -A font_filetypes
 	local otf_file_number ttf_file_number
 
-	otf_file_number=$(ls ${S} | grep -i otf | wc -l)
-	ttf_file_number=$(ls ${S} | grep -i ttf | wc -l)
+	otf_file_number=$(find ${S} -regex '.*\.otf' | wc -l)
+	ttf_file_number=$(find ${S} -regex '.*\.ttf' | wc -l)
 
 	if [[ ${otf_file_number} != 0 ]]; then
 		font_filetypes[otf]=

--- a/media-fonts/nerd-fonts/nerd-fonts-3.0.2.ebuild
+++ b/media-fonts/nerd-fonts/nerd-fonts-3.0.2.ebuild
@@ -168,8 +168,8 @@ src_install() {
 	declare -A font_filetypes
 	local otf_file_number ttf_file_number
 
-	otf_file_number=$(ls ${S} | grep -i otf | wc -l)
-	ttf_file_number=$(ls ${S} | grep -i ttf | wc -l)
+	otf_file_number=$(find ${S} -regex '.*\.otf' | wc -l)
+	ttf_file_number=$(find ${S} -regex '.*\.ttf' | wc -l)
 
 	if [[ ${otf_file_number} != 0 ]]; then
 		font_filetypes[otf]=


### PR DESCRIPTION
`ls` is unreliable when filenames have whitespaces in them (even though current iteration of Nerd fonts doesn't), `find` is the better solution